### PR TITLE
Use main Wiki page instead of mobile one

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -72,7 +72,7 @@
 		<meta property="role" refines="#author" scheme="marc:relators">aut</meta>
 		<dc:contributor id="artist">Édouard Odier</dc:contributor>
 		<meta property="file-as" refines="#artist">Odier, Édouard</meta>
-		<meta property="se:url.encyclopedia.wikipedia" refines="#artist">https://fr.m.wikipedia.org/wiki/%C3%89douard_Odier</meta>
+		<meta property="se:url.encyclopedia.wikipedia" refines="#artist">https://fr.wikipedia.org/wiki/%C3%89douard_Odier</meta>
 		<meta property="se:url.authority.nacoaf" refines="#artist">http://id.loc.gov/authorities/names/no2007007003</meta>
 		<meta property="role" refines="#artist" scheme="marc:relators">art</meta>
 		<dc:contributor id="transcriber-1">Jeremy Hylton</dc:contributor>


### PR DESCRIPTION
While I was looking to see if we allowed non-english Wiki pages, I saw this one that was pointing to the mobile version of the page.